### PR TITLE
Fix for EEST timezone

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+    def main

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,62 @@
 .idea
 *.iml
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false # Use container-based infrastructure
 python:
   - "2.7"
 install:

--- a/batlog2csv.py
+++ b/batlog2csv.py
@@ -121,6 +121,15 @@ class Batlog2Csv:
         except:
             pass
 
+        # For dates like "Sun Mar 29 10:28:00 EEST 2015"
+        try:
+            value = datetime.datetime.strptime(
+                string[:20] + string[24:],
+                "%a %b %d %H:%M:%S %Y"
+            )
+        except:
+            pass
+
         if value:
             key = Batlog2Csv.DATE_KEY
             is_date = True

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -41,6 +41,46 @@ def test_that_date_with_timezone_as_last_part_is_parsed_correctly():
     assert parsed_date.second == second
 
 
+def test_that_date_with_eet_timezone_is_parsed_correctly():
+    date_string = "Sat Mar 28 12:58:00 EET 2015"
+    year = 2015
+    month = 3
+    day = 28
+    hour = 12
+    minute = 58
+    second = 0
+
+    key, parsed_date, is_date = Batlog2Csv.parse_date(date_string)
+
+    assert is_date
+    assert parsed_date.year == year
+    assert parsed_date.month == month
+    assert parsed_date.day == day
+    assert parsed_date.hour == hour
+    assert parsed_date.minute == minute
+    assert parsed_date.second == second
+
+
+def test_that_date_with_eest_timezone_is_parsed_correctly():
+    date_string = "Sun Mar 29 10:28:00 EEST 2015"
+    year = 2015
+    month = 3
+    day = 29
+    hour = 10
+    minute = 28
+    second = 0
+
+    key, parsed_date, is_date = Batlog2Csv.parse_date(date_string)
+
+    assert is_date
+    assert parsed_date.year == year
+    assert parsed_date.month == month
+    assert parsed_date.day == day
+    assert parsed_date.hour == hour
+    assert parsed_date.minute == minute
+    assert parsed_date.second == second
+
+
 def test_that_standard_datetime_string_is_parsed_correctly():
     date_string = "2013-11-05 18:11:00"
     year = 2013


### PR DESCRIPTION
Thanks for this script and batlog-d3-chart!

I ran it but there was a big gap during summertime. This is because Finland's timezones are EET in winter and EEST in summer.

Here's a test for EET (passes before and after) and EEST (fails before, passes after) and a fix.

---

Also:
- Use container-based infrastructure on Travis CI: https://docs.travis-ci.com/user/workers/container-based-infrastructure/
- Expand the .gitignore, mainly to ignore *.pyc but also some other common things, taken from: https://github.com/github/gitignore
- Exclude untestable main from coverage.
